### PR TITLE
[SP-9575] convert multipart object param from string back to object before validation

### DIFF
--- a/lib/prepare-params.js
+++ b/lib/prepare-params.js
@@ -53,6 +53,13 @@ module.exports = function(event, context) {
               if (event.request.files) { params[param.name] = event.request.files[param.name]; }
             } else if (event.request.body) {
               params[param.name] = event.request.body[param.name];
+              if (param.type === 'object') {
+                try {
+                  params[param.name] = params[param.name] && JSON.parse(params[param.name]);
+                } catch (e) {
+                  params[param.name] = 'error'; // let the validator err
+                }
+              }
             }
             break;
           case 'bodyStream':

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bravado-core",
-  "version": "0.13.7",
+  "version": "0.13.8",
   "description": "REST (Level 3/HATEOAS) API Framework",
   "directories": {
     "lib": "lib"


### PR DESCRIPTION
SP-9575

PR 2 of 2 see the other [here](https://github.com/Losant/bravado-client-generator/pull/22)

this converts the stringified multipart param back into a json object prior to schema validation so we may cutely allow them to pass the validation check